### PR TITLE
Add create movie endpoint and incomplete logic

### DIFF
--- a/movie_service/urls.py
+++ b/movie_service/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('movies/', views.get_movies_detail)
+    path('movies/', views.get_movies_detail),
+    path('movies/create', views.create_movie)
 ]

--- a/movie_service/views.py
+++ b/movie_service/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, parser_classes
+from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from .models import Movie
 
@@ -15,3 +16,20 @@ def get_movies_detail(request):
                               "cinema": movie.cinema,
                               })
     return Response(movies_detail)
+
+# TODO: Authenticate the request
+@api_view(['POST'])
+@parser_classes([MultiPartParser])
+def create_movie(request):
+    title = request.data['title']
+    cinema = request.data['cinema']
+    description = request.data['description']
+    # TODO: Handle file later
+    movie = Movie.objects.create(title=title, cinema=cinema, description=description)
+    # thumbnail = request.data['thumbnail']
+    return Response({
+        "id": movie.id,
+        "title": movie.title,
+        "description": movie.description,
+        "cinema": movie.cinema
+    })

--- a/movie_service/views.py
+++ b/movie_service/views.py
@@ -25,6 +25,9 @@ def create_movie(request):
     cinema = request.data['cinema']
     description = request.data['description']
     # TODO: Handle file later
+    # Please also note lack of validation here.
+    # We don't have logic to validate anything yet
+    # - Pontakorn Paesaeng
     movie = Movie.objects.create(title=title, cinema=cinema, description=description)
     # thumbnail = request.data['thumbnail']
 

--- a/movie_service/views.py
+++ b/movie_service/views.py
@@ -27,6 +27,10 @@ def create_movie(request):
     # TODO: Handle file later
     movie = Movie.objects.create(title=title, cinema=cinema, description=description)
     # thumbnail = request.data['thumbnail']
+
+    # Note: I think movies service might need to send something to reservation service here.
+    # The alternate solution is to allow create showtime independently but that is not consistent.
+    # - Pontakorn Paesaeng
     return Response({
         "id": movie.id,
         "title": movie.title,


### PR DESCRIPTION
# Changes
- Add endpoint for adding a movie for administrator
- No authorization yet
- No image handling (No upload to S3)
- No creating reservation

# Note
- Image handling should be done after making sure that configuration is not hard-coded
- This also include authorization as I must set the `SIGNING_KEY` to be the same as authentication service.